### PR TITLE
Simpler theme installation, with proper caching

### DIFF
--- a/theme-installer.sh
+++ b/theme-installer.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Download and install requirements for documentation auto-deployment.
+#
+# This script does the following:
+#
+# - Installs mkdocs under the current user.
+# - Installs pymdown-extensions under the current user.
+# - If the zf-mkdoc-theme is not present under the current directory, downloads
+#   and installs the latest tarball.
+#
+# In order to work, it needs the following environment variables defined:
+#
+# This script should be fetched from the master branch by any project opting
+# into the documentation auto-deployment workflow.
+#
+# @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+# @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+
+SCRIPT_PATH="$(pwd)"
+
+# Install mkdocs and required extensions.
+pip install --user mkdocs
+pip install --user pymdown-extensions
+
+# Conditionally install zf-mkdoc-theme.
+if [[ ! -d "zf-mkdoc-theme/theme" ]];then
+    echo "Downloading zf-mkdoc-theme..." ;
+    mkdir -p zf-mkdoc-theme ;
+    curl -s -L https://github.com/zendframework/zf-mkdoc-theme/releases/latest | egrep -o '/zendframework/zf-mkdoc-theme/archive/[0-9]*\.[0-9]*\.[0-9]*\.tar\.gz' | head -n1 | wget -O zf-mkdoc-theme.tgz --base=https://github.com/ -i - ;
+    (
+        cd zf-mkdoc-theme ;
+        tar xzf ../zf-mkdoc-theme.tgz --strip-components=1 ;
+    );
+    echo "Finished downloading and installing zf-mkdoc-theme" ;
+fi
+
+exit 0;


### PR DESCRIPTION
I noticed after we went live with the build automation that caching occurs immediately after the `script` runs, before any other items in the Travis workflow — which meant that no caching of the MkDocs installation or zf-mkdoc-theme was occurring.

I reached out to Travis to find out how I might get the behavior I want, and they suggested doing the deployment via a shell script at the end of the `script` section, but only in the case that the current build status was successful, which you can test via the `$TRAVIS_TEST_RESULT` variable.

This patch adds a script, `theme-installer.sh`, which:

- Installs MkDocs and related extensions via `pip`;
- downloads and installs the latest release of this repository.

Doing this vastly simplifies the setup as well; with this change, I was able to reduce the number of changes to the `.travis.yml` by around 66%.

I tested the changes rigorously on my zf-docs-toolchain-experiment repository, and can confirm that:

- With no cache contents, it correctly installs MkDocs and extensions, and the zf-mkdoc-theme;
- With cache contents, the installer script installs nothing.

I chose to not cache the installer script, in the event that we want to install additional items later. Additionally, I run it whenever the deployment branch is selected and the script is successful, without testing for the presence of assets. This was done for a few reasons:

- I had huge issues with Travis correctly interpreting filesystem tests previously, and felt it was simpler all around to avoid that madness;
- If the installer changes over time, we want to ensure that any *new* items are present after installation as well, without requiring updates to the component calling on it.

The changes at this time are completely backwards compatible. I'll update the Expressive repository to adopt the simpler Travis-CI setup, but it will continue to run without changes.