### PR TITLE
Allow marking files to preserve between builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,8 +28,26 @@ echo "        use_pygments: False" >> mkdocs.yml
 echo "    - pymdownx.superfences" >> mkdocs.yml
 echo "theme_dir: zf-mkdoc-theme/theme" >> mkdocs.yml
 
+# Preserve files if necessary (as mkdocs build --clean removes all files)
+if [ -e .zf-mkdoc-theme-preserve ]; then
+    mkdir .preserve
+    for PRESERVE in $(cat .zf-mkdoc-theme-preserve); do
+        cp doc/html/${PRESERVE} .preserve/
+    done
+fi
+
 mkdocs build --clean
+
+# Restore mkdocs.yml
 mv mkdocs.yml.orig mkdocs.yml
+
+# Restore files if necessary
+if [ -e .zf-mkdoc-theme-preserve ]; then
+    for PRESERVE in $(cat .zf-mkdoc-theme-preserve); do
+        mv .preserve/${PRESERVE} doc/html/${PRESERVE}
+    done
+    rm -Rf ./preserve
+fi
 
 # Make images responsive
 echo "Making images responsive"


### PR DESCRIPTION
zend-component-installer published a phar, along with a public key and version file. To ensure that already downloaded phars continue to work, these need to remain. However, `mkdocs build --clean` removes *all* files in the target directory prior to building, which strips them out.

This patch alters `build.sh` to:

- Prior to calling `mkdocs`, check if a `.zf-mkdoc-theme-preserve` file exists; if so, the files listed in it are copied to a `.preserve/` directory.
- After calling `mkdocs`, if `.zf-mkdoc-theme-preserve` exists, all files under `.preserve/` are moved back to the build target directory, and the `.preserve/` directory is removed.