### PR TITLE
Need to do a reset --hard

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -41,7 +41,7 @@ mkdir -p doc/html
     git config user.email "${GH_USER_EMAIL}"
     git remote add upstream "https://${GH_TOKEN}@${GH_REF}"
     git fetch upstream
-    git reset upstream/gh-pages
+    git reset --hard upstream/gh-pages
 )
 
 # Build the documentation


### PR DESCRIPTION
Without the `--hard` switch, *no files are added to the directory*. This makes it impossible to preserve files. Adding the switch ensures they're in the tree, and `mkdocs build --clean` will do the work of removing them.