### PR TITLE
Removes invalid CSS property value 'relative'

### DIFF
--- a/theme/css/zf-web.css
+++ b/theme/css/zf-web.css
@@ -310,7 +310,6 @@ a:focus {
     margin-top: 0px;
 	padding-top:60px;
 	text-align:center;
-	background-attachment: relative;
 	background-position: center center;
 	min-height: 450px;
 	width: 100%;
@@ -348,7 +347,6 @@ a:focus {
     margin-top: 0px;
 	padding-top:60px;
 	text-align:center;
-	background-attachment: relative;
 	background-position: center center;
 	min-height: 450px;
 	width: 100%;
@@ -490,7 +488,6 @@ csmall {
 	margin-top: -60px;
 	padding-top:0px;
 	text-align:center;
-	background-attachment: relative;
 	background-position: center center;
 	min-height: 400px;
 	width: 100%;


### PR DESCRIPTION
Standard value is `scroll` and the right choice for all background images.
