### PR TITLE
Allows building docs from either doc or docs dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,8 +33,13 @@ while getopts hu: option;do
     esac
 done
 
+DOC_DIR=doc
+if [ -d "docs" ];then
+    DOC_DIR=docs
+fi
+
 # Update the mkdocs.yml
-echo "Building documentation"
+echo "Building documentation in ${DOC_DIR}"
 cp mkdocs.yml mkdocs.yml.orig
 echo "site_url: ${SITE_URL}"
 echo "markdown_extensions:" >> mkdocs.yml
@@ -47,7 +52,7 @@ echo "theme_dir: zf-mkdoc-theme/theme" >> mkdocs.yml
 if [ -e .zf-mkdoc-theme-preserve ]; then
     mkdir .preserve
     for PRESERVE in $(cat .zf-mkdoc-theme-preserve); do
-        cp doc/html/${PRESERVE} .preserve/
+        cp ${DOC_DIR}/html/${PRESERVE} .preserve/
     done
 fi
 
@@ -59,19 +64,19 @@ mv mkdocs.yml.orig mkdocs.yml
 # Restore files if necessary
 if [ -e .zf-mkdoc-theme-preserve ]; then
     for PRESERVE in $(cat .zf-mkdoc-theme-preserve); do
-        mv .preserve/${PRESERVE} doc/html/${PRESERVE}
+        mv .preserve/${PRESERVE} ${DOC_DIR}/html/${PRESERVE}
     done
     rm -Rf ./preserve
 fi
 
 # Make images responsive
 echo "Making images responsive"
-php ${SCRIPT_PATH}/img_responsive.php
+php ${SCRIPT_PATH}/img_responsive.php ${DOC_DIR}
 
 # Make tables responsive
 echo "Making tables responsive"
-php ${SCRIPT_PATH}/table_responsive.php
+php ${SCRIPT_PATH}/table_responsive.php ${DOC_DIR}
 
 # Replace landing page content
 echo "Replacing landing page content"
-php ${SCRIPT_PATH}/swap_index.php
+php ${SCRIPT_PATH}/swap_index.php ${DOC_DIR}

--- a/deploy.sh
+++ b/deploy.sh
@@ -49,7 +49,12 @@ if [[ -z ${GH_USER_NAME} || -z ${GH_USER_EMAIL} || -z ${GH_TOKEN} || -z ${GH_REF
     exit 1;
 fi
 
-echo "Preparing to build and deploy documentation"
+DOC_DIR=doc
+if [ -d "docs" ];then
+    DOC_DIR=docs
+fi
+
+echo "Preparing to build and deploy documentation in ${DOC_DIR}"
 
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd -P)"
 
@@ -57,9 +62,9 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd -P)"
 rev=$(git rev-parse --short HEAD)
 
 # Initialize gh-pages checkout
-mkdir -p doc/html
+mkdir -p ${DOC_DIR}/html
 (
-    cd doc/html
+    cd ${DOC_DIR}/html
     git init
     git config user.name "${GH_USER_NAME}"
     git config user.email "${GH_USER_EMAIL}"
@@ -73,7 +78,7 @@ ${SCRIPT_PATH}/build.sh -u ${SITE_URL}
 
 # Commit and push the documentation to gh-pages
 (
-    cd doc/html
+    cd ${DOC_DIR}/html
     touch .
     git add -A .
     git commit -m "Rebuild pages at ${rev}"

--- a/img_responsive.php
+++ b/img_responsive.php
@@ -6,7 +6,9 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
-$docPath = realpath(getcwd() . '/doc');
+$docPath = isset($argv[1]) ? $argv[1] : 'doc';
+$docPath = sprintf('%s/%s', getcwd(), $docPath);
+$docPath = realpath($docPath);
 
 $rdi = new RecursiveDirectoryIterator($docPath . '/html');
 $rii = new RecursiveIteratorIterator($rdi, RecursiveIteratorIterator::SELF_FIRST);

--- a/swap_index.php
+++ b/swap_index.php
@@ -6,7 +6,9 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
-$docPath = realpath(getcwd() . '/doc');
+$docPath = isset($argv[1]) ? $argv[1] : 'doc';
+$docPath = sprintf('%s/%s', getcwd(), $docPath);
+$docPath = realpath($docPath);
 
 $target = file_get_contents($docPath . '/html/index.html');
 $source = file_get_contents($docPath . '/book/index.html');

--- a/table_responsive.php
+++ b/table_responsive.php
@@ -6,7 +6,9 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
-$docPath = realpath(getcwd() . '/doc');
+$docPath = isset($argv[1]) ? $argv[1] : 'doc';
+$docPath = sprintf('%s/%s', getcwd(), $docPath);
+$docPath = realpath($docPath);
 
 $rdi = new RecursiveDirectoryIterator($docPath . '/html');
 $rii = new RecursiveIteratorIterator($rdi, RecursiveIteratorIterator::SELF_FIRST);


### PR DESCRIPTION
GitHub uses either the `.github/` or `docs/` directories to hold things such as the contributors guide, code of conduct, issue and pull request templates, etc. To reduce the number of folders required in the top-level directory, we can easily re-purpose our own documentation directory, as we place documentation under its `book/` subdirectory, and build in the `html/` subdirectory.

This patch adds support to detect if a `docs/` directory exists, and, if so, it will assume that that directory should be used as the root for documentation.