### PR TITLE
Fix pipes in table cells

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -83,6 +83,10 @@ php ${SCRIPT_PATH}/img_responsive.php ${DOC_DIR}
 echo "Making tables responsive"
 php ${SCRIPT_PATH}/table_responsive.php ${DOC_DIR}
 
+# Fix pipes in tables
+echo "Fixing pipes in tables"
+php ${SCRIPT_PATH}/table_fix_pipes.php ${DOC_DIR}
+
 # Replace landing page content
 echo "Replacing landing page content"
 php ${SCRIPT_PATH}/swap_index.php ${DOC_DIR}

--- a/table_fix_pipes.php
+++ b/table_fix_pipes.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Replace \| to | in table cells.
+ *
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+$docPath = isset($argv[1]) ? $argv[1] : 'doc';
+$docPath = sprintf('%s/%s', getcwd(), $docPath);
+$docPath = realpath($docPath);
+
+$rdi = new RecursiveDirectoryIterator($docPath . '/html');
+$rii = new RecursiveIteratorIterator($rdi, RecursiveIteratorIterator::SELF_FIRST);
+$files = new RegexIterator($rii, '/\.html$/', RecursiveRegexIterator::GET_MATCH);
+
+$process = function () use ($files) {
+    $fileInfo = $files->getInnerIterator()->current();
+    if (! $fileInfo->isFile()) {
+        return true;
+    }
+
+    if ($fileInfo->getBasename('.html') === $fileInfo->getBasename()) {
+        return true;
+    }
+
+    $file = $fileInfo->getRealPath();
+    $html = file_get_contents($file);
+    if (! preg_match('#<table[^>]*>.*?(<\/table>)#s', $html)) {
+        return true;
+    }
+    $matches = [];
+    if (preg_match_all('/<td[^>]*>.*?<\/td>/s', $html, $matches)) {
+        foreach ($matches[0] as $origin) {
+            $count = 0;
+            $content = str_replace('\|', '|', $origin, $count);
+            if ($count) {
+                $html = str_replace($origin, $content, $html);
+            }
+        }
+    }
+    file_put_contents($file, $html);
+
+    return true;
+};
+
+iterator_apply($files, $process);

--- a/table_fix_pipes.php
+++ b/table_fix_pipes.php
@@ -30,7 +30,7 @@ $process = function () use ($files) {
         return true;
     }
     $matches = [];
-    if (preg_match_all('/<td[^>]*>.*?<\/td>/s', $html, $matches)) {
+    if (preg_match_all('/<table[^>]*>.*?<\/table>/s', $html, $matches)) {
         foreach ($matches[0] as $origin) {
             $count = 0;
             $content = str_replace('\|', '|', $origin, $count);


### PR DESCRIPTION
In markdown notation we have to escape pipes in tables:
we have to use `\|` instead of `|` because it is cell separator.

HTML generator unfortunately left these pipes escaped, so we have
to replace escaped pipes in table cells to be not escaped.

For more information please see:
https://github.com/zendframework/zend-navigation/issues/65