### PR TITLE
Provide a way to redirect to another page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,47 @@ theme, by Chris Simpkins, with a number of modifications, including:
 The theme itself resides in `theme/`. Also included are tools for building and
 deploying documentation.
 
+## Redirects
+
+If you want a page to redirect to another URL, and not appear in the navigation,
+this theme supports that by allowing you to prefix the title of such a page with
+`_` within the `mkdocs.yml` file:
+
+```yaml
+pages:
+    - index.md
+    - "_intro": intro.md
+    - "Intro": v2/intro.md
+```
+
+In order to create the redirect, you will need to create two HTML artifacts in
+your markdown file:
+
+- A meta refresh tag, for when javascript is not present.
+- A `DOMContentLoaded` listener.
+
+In the example above, the contents of `intro.md` would then look like the
+following:
+
+```markdown
+<noscript><meta http-equiv="refresh" content="0; url=v2/intro/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var uri = new URL(window.location.href);
+    uri.pathname = 'v2/intro/';
+    window.location = uri.href;
+  });
+</script>
+```
+
+When the pages are built, the path `/intro/` will still be present, but the page
+will not be linked in the navigation. Additionally, that page will place the
+fully rendered markdown contents _within the `<head>` tag of the document_.
+
+This approach allows the legacy URL to still resolve, ensuring existing links
+continue to work. The presence of the redirect ensures the user is redirected to
+reasonable content, and that search engines will stop linking the old URL.
+
 ## gh-pages automation
 
 We formerly used Travis-CI for building documentation. However, this meant

--- a/theme/main.html
+++ b/theme/main.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 
+{% if page.title and page.title.startswith("_") %}
+<head>
+  {{ page.content }}
+</head>
+{% else %}
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -93,6 +98,7 @@
     {% include "dropdown.html" %}
 
 </body>
+{% endif %}
 
 </html>
 {% if page and page.is_homepage %}

--- a/theme/nav-sub.html
+++ b/theme/nav-sub.html
@@ -1,7 +1,9 @@
 {% if not nav_item.children %}
+{% if not nav_item.title.startswith("_") %}
 <li {% if nav_item.active %}class="active"{% endif %}>
     <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
 </li>
+{% endif %}
 {% else %}
   <li class="dropdown-submenu">
     <a tabindex="-1" href="">{{ nav_item.title }}</a>

--- a/theme/nav.html
+++ b/theme/nav.html
@@ -36,9 +36,11 @@
                         </ul>
                     </li>
                 {% else %}
+                    {% if not nav_item.title.startswith("_") %}
                     <li {% if nav_item.active %}class="active"{% endif %}>
                         <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
                     </li>
+                    {% endif %}
                 {% endif %}
                 {% endfor %}
                 </ul>


### PR DESCRIPTION
This is a hack learned from the mkdocs issue tracker:

- https://github.com/mkdocs/mkdocs/issues/699#issuecomment-176948725

Essentially, with this in place, if a page _title_ begins with `_`, it will not be included in the navigation.

Additionally, this patch goes a step further, and the rendered markdown of such pages is injected only into the `<head>` section of the built document, with no other content. This allows for a very quick redirect, with no content present to index.

This is useful when you want to preserve link continuity. The old page can continue to exist, but no pages on the site will reference it, which means that search engines will eventually stop crawling it.

The stated recommendation in the README is to replace the contents of that page with JS and/or a meta refresh in order to force a redirect once loaded; most search engines will notice these and honor them, removing the page from their search results.