### PR TITLE
Allows individual components to opt-in to a custom landing page

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,5 +88,7 @@ echo "Fixing pipes in tables"
 php ${SCRIPT_PATH}/table_fix_pipes.php ${DOC_DIR}
 
 # Replace landing page content
-echo "Replacing landing page content"
-php ${SCRIPT_PATH}/swap_index.php ${DOC_DIR}
+if [ -e .zf-mkdoc-theme-landing ]; then
+    echo "Replacing landing page content"
+    php ${SCRIPT_PATH}/swap_index.php ${DOC_DIR}
+fi

--- a/theme/main.html
+++ b/theme/main.html
@@ -34,9 +34,11 @@
     <div class="container">
         <div class="row">
             <div class="col-md-9 col-xs-12 content" role="main">
+            <!-- content:begin -->
                 {% block content %}
                     {% include "content.html" %}
                 {% endblock %}
+            <!-- content:end -->
             </div>
             <div class="col-md-3 col-xs-12 sidebar">
                 {% if config.site_name != 'Documentation' %}


### PR DESCRIPTION
Modifies the `build.sh` script to look for a file in the package root, `.zf-mkdoc-theme-landing`; when found, it will run the `swap_index.php` script.

Alters the `main.html` file of the theme to add the missing comments that allowed swapping in content.

This approach ensures that components that have the `index.html` defined **will not** swap in their contents **unless** a commit is made that adds the `.zf-mkdoc-theme-landing` file.