### PR TITLE
Discover the doc_dir from mkdocs.yml, and use it to create the edit_uri

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,10 +33,10 @@ while getopts hu: option;do
     esac
 done
 
-DOC_DIR=doc
-if [ -d "docs" ];then
-    DOC_DIR=docs
-fi
+cp mkdocs.yml mkdocs.yml.orig
+
+DOCS_DIR=$(php ${SCRIPT_PATH}/discover_doc_dir.php)
+DOC_DIR=$(dirname ${DOCS_DIR})
 
 # Build assets
 echo "Building assets"
@@ -44,7 +44,6 @@ ${SCRIPT_PATH}/asset.sh
 
 # Update the mkdocs.yml
 echo "Building documentation in ${DOC_DIR}"
-cp mkdocs.yml mkdocs.yml.orig
 echo "site_url: ${SITE_URL}"
 echo "extra:" >> mkdocs.yml
 cat zf-mkdoc-theme/assets.yml >> mkdocs.yml
@@ -52,7 +51,10 @@ echo "markdown_extensions:" >> mkdocs.yml
 echo "    - markdown.extensions.codehilite:" >> mkdocs.yml
 echo "        use_pygments: False" >> mkdocs.yml
 echo "    - pymdownx.superfences" >> mkdocs.yml
-echo "theme_dir: zf-mkdoc-theme/theme" >> mkdocs.yml
+echo "theme:" >> mkdocs.yml
+echo "    name: null" >> mkdocs.yml
+echo "    custom_dir: zf-mkdoc-theme/theme" >> mkdocs.yml
+echo "edit_uri: edit/master/${DOCS_DIR}/" >> mkdocs.yml
 
 # Preserve files if necessary (as mkdocs build --clean removes all files)
 if [ -e .zf-mkdoc-theme-preserve ]; then

--- a/discover_doc_dir.php
+++ b/discover_doc_dir.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Determine the documentation directory from the mkdocs.yml
+ *
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+$projectPath = realpath(getcwd());
+$mkdocsYmlPath = $projectPath . '/mkdocs.yml';
+$yaml = file_get_contents($mkdocsYmlPath);
+
+if (preg_match('#^docs_dir:\s*(?P<path>.*?)$#m', $yaml, $matches)) {
+    echo trim($matches['path']);
+    exit(0);
+}
+
+if (is_dir($projectPath . '/docs')) {
+    echo 'docs/book';
+    exit(0);
+}
+
+echo 'doc/book';
+exit(0);


### PR DESCRIPTION
Parses the `mkdocs.yml` for the `docs_dir` setting. If found, it returns that verbatim.

Next, it looks for a `docs/` directory under the current working dir. If found, it emits the value `docs/book`.

Otherwise, it emits `doc/book`.

This value is then used in two places:

- `DOC_DIR` is set to `dirname {value}`
- `DOCS_DIR` is set to the value, and used to create the `edit_uri` mkdocs setting.

Additionally, this generates the correct `theme` mkdocs configuration (instead of using `theme_dir`, which is deprecated).

Fixes #40