### PR TITLE
Fixes the component dropdown when in the navbar

### DIFF
--- a/asset/js/component-list.js
+++ b/asset/js/component-list.js
@@ -1,6 +1,10 @@
 (function () {
     "use strict";
 
+    function getContainerElements() {
+        return Array.prototype.concat.apply([], document.getElementsByClassName('component-selector'));
+    }
+
     function getSelectElements() {
         return Array.prototype.concat.apply([], document.getElementsByClassName('component-selector__control'));
     }
@@ -52,7 +56,6 @@
         });
 
         // Initialize the Choices selector using the component selector as its element
-        // document.getElementsByClassName('component-selector__control');
         getSelectElements().forEach(function(element) {
             const choices = new Choices(element, {
                 itemSelectText: '',
@@ -73,8 +76,22 @@
             );
 
             // On selection of a choice, redirect to its URL
-            choices.passedElement.addEventListener('choice', function (event) {
+            element.addEventListener('choice', function (event) {
                 window.location.href = event.detail.choice.value;
+            }, false);
+
+            // Ensure the parent container expands to fit the list...
+            element.addEventListener('showDropdown', function (event) {
+                getContainerElements().forEach(function (container) {
+                    container.parentElement.style.minHeight = container.clientHeight + 350 + "px";
+                });
+            }, false);
+
+            // ... and then shrinks back to size again.
+            element.addEventListener('hideDropdown', function (event) {
+                getContainerElements().forEach(function (container) {
+                    container.parentElement.style.minHeight = 'unset';
+                });
             }, false);
         });
     }

--- a/asset/js/component-list.js
+++ b/asset/js/component-list.js
@@ -1,6 +1,10 @@
 (function () {
     "use strict";
 
+    function getSelectElements() {
+        return Array.prototype.concat.apply([], document.getElementsByClassName('component-selector__control'));
+    }
+
     function prepareComponentList(components) {
         var componentList = {
             learn: {
@@ -48,28 +52,31 @@
         });
 
         // Initialize the Choices selector using the component selector as its element
-        const choices = new Choices(document.getElementsByClassName('component-selector__control')[1], {
-            itemSelectText: '',
-            renderChoiceLimit: -1,
-            searchChoices: true,
-            searchEnabled: true,
-            searchFields: ['label', 'customProperties.description'],
-            searchPlaceholderValue: 'Jump to package documentation...',
-            searchResultLimit: 10,
-            shouldSort: false
+        // document.getElementsByClassName('component-selector__control');
+        getSelectElements().forEach(function(element) {
+            const choices = new Choices(element, {
+                itemSelectText: '',
+                renderChoiceLimit: -1,
+                searchChoices: true,
+                searchEnabled: true,
+                searchFields: ['label', 'customProperties.description'],
+                searchPlaceholderValue: 'Jump to package documentation...',
+                searchResultLimit: 10,
+                shouldSort: false
+            });
+
+            choices.setChoices(
+                Array.prototype.concat.apply(Object.values(componentList), uncategorized),
+                'value',
+                'label',
+                true
+            );
+
+            // On selection of a choice, redirect to its URL
+            choices.passedElement.addEventListener('choice', function (event) {
+                window.location.href = event.detail.choice.value;
+            }, false);
         });
-
-        choices.setChoices(
-            Array.prototype.concat.apply(Object.values(componentList), uncategorized),
-            'value',
-            'label',
-            true
-        );
-
-        // On selection of a choice, redirect to its URL
-        choices.passedElement.addEventListener('choice', function (event) {
-            window.location.href = event.detail.choice.value;
-        }, false);
     }
 
     function parseComponentList(event) {

--- a/asset/js/component-list.js
+++ b/asset/js/component-list.js
@@ -83,7 +83,8 @@
             // Ensure the parent container expands to fit the list...
             element.addEventListener('showDropdown', function (event) {
                 getContainerElements().forEach(function (container) {
-                    container.parentElement.style.minHeight = container.clientHeight + 350 + "px";
+                    const choicesList = container.querySelector('.choices__list--dropdown');
+                    container.parentElement.style.minHeight = container.clientHeight + choicesList.clientHeight + "px";
                 });
             }, false);
 


### PR DESCRIPTION
First, the previous solution in #45 was only styling the `Choices.js` dropdown found in the sidebar; we need it to style the one in the navbar as well.

Second, On mobile devices, the `Choices.js` dropdown cannot currently expand past the size of the parent container (the navbar row). Additionally, for pages such as the docs landing page, the sidebar height is quite short, not allowing enough height for the dropdown.

This patch modifies the `component-dropdown.js` as follows:

- It loops through all nodes matching `.component-dropdown__control`, attaching a `Choices.js` dropdown to each.
- It adds an event listener to the `showDropdown` event, expanding the `min-height` style of the parents of the `.component-selector` elements by the height of the `.choices__list--dropdown` element found in the `.component-selector`.
- It adds an event listener to the `hideDropdown` event, unsetting the `min-height` style of the parents of the `.component-selector`.
