### PR TITLE
Removes background color and padding for code elements in headlines

### DIFF
--- a/asset/sass/_elements.scss
+++ b/asset/sass/_elements.scss
@@ -3,7 +3,15 @@ h2,
 h3,
 h4,
 h5,
-h6,
+h6 {
+    word-wrap: break-word;
+
+    code {
+        padding: 0;
+        background-color: transparent;
+    }
+}
+
 code {
     word-wrap: break-word;
 }


### PR DESCRIPTION
## Before
![docs zendframework com_zend-modulemanager_best-practices_ screenshots fur website](https://user-images.githubusercontent.com/103362/46715191-45cfb600-cc5f-11e8-9502-58fc03056e02.png)

## After
![docs zendframework com_zend-modulemanager_best-practices_ screenshots fur website -1](https://user-images.githubusercontent.com/103362/46715193-47997980-cc5f-11e8-85ff-1fe9bfaf01b7.png)

