### PR TITLE
Sets the bottom section level for the table of contents to 2 (h2)

### DIFF
--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -27,7 +27,12 @@ mkdocs["markdown_extensions"] = [
                 "template": "bootstrap3"
             }
         },
-        "pymdownx.superfences"
+        "pymdownx.superfences",
+        {
+            "toc": {
+                "toc_depth": 2
+            }
+        }
     ]
 
 mkdocs["theme"] = {


### PR DESCRIPTION
Only the headlines of the second order should be include in the table of
contents.

See: https://python-markdown.github.io/extensions/toc/#usage