### PR TITLE
Updates order of Markdown extensions in update script for MkDocs config

### DIFF
--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -22,12 +22,12 @@ mkdocs["markdown_extensions"] = [
                 "use_pygments": False
             }
         },
+        "pymdownx.superfences",
         {
             "markdown_fenced_code_tabs": {
                 "template": "bootstrap3"
             }
-        },
-        "pymdownx.superfences"
+        }
     ]
 
 mkdocs["theme"] = {


### PR DESCRIPTION
The new order fixes a problem on rendering with tabs for code examples.
See: https://docs.zendframework.com/zend-view/helpers/html-tag/#using-attributes

/cc @webimpress