### PR TITLE
Strip tags on description

### DIFF
--- a/theme/main.html
+++ b/theme/main.html
@@ -10,7 +10,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">{% if config.site_description %}
-    <meta name="description" content="{{ config.site_description }}">{% endif %} {% if config.site_author %}
+    <meta name="description" content="{{ config.site_description|striptags }}">{% endif %} {% if config.site_author %}
     <meta name="author" content="{{ config.site_author }}">{% endif %} {% if page.canonical_url %}
     <link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
     <link rel="shortcut icon" href="{{ 'img/favicon.ico'|url }}">


### PR DESCRIPTION
So we can use tags in the description (like link to be present on the
main library page) - for example zend-http:

```
HTTP message and header abstractions, and HTTP client implementation.  (Not a PSR-7 implementation; see <a href="//docs.zendframework.com/zend-diactoros">Diactoros</a> for PSR-7 support.
```