### PR TITLE
Hotfix: edit link - correct path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ DOC_DIR=$(dirname ${DOCS_DIR})
 
 # Update the mkdocs.yml
 echo "Building documentation in ${DOC_DIR}"
-${SCRIPT_PATH}/update_mkdocs_yml.py ${SITE_URL} ${DOC_DIR}
+${SCRIPT_PATH}/update_mkdocs_yml.py ${SITE_URL} ${DOCS_DIR}
 
 # Preserve files if necessary (as mkdocs build --clean removes all files)
 if [ -e .zf-mkdoc-theme-preserve ]; then


### PR DESCRIPTION
`docs_dir` is `docs/book`
`doc_dir` is `dirname(docs_dir) = docs`

the same for uppercase vars