### PR TITLE
Adds list for component groups in JSON format

### DIFF
--- a/scripts/zf-component-groups.json
+++ b/scripts/zf-component-groups.json
@@ -1,0 +1,27 @@
+[
+    {
+        "key": "learn",
+        "name": "Learn ZF",
+        "sort": 1
+    },
+    {
+        "key": "mvc",
+        "name": "MVC Framework",
+        "sort": 2
+    },
+    {
+        "key": "middleware",
+        "name": "Expressive and PSR-15 Middleware",
+        "sort": 3
+    },
+    {
+        "key": "projects",
+        "name": "Tooling and Composer Plugins",
+        "sort": 4
+    },
+    {
+        "key": "components",
+        "name": "Components",
+        "sort": 5
+    }
+]


### PR DESCRIPTION
This can be used as a replacement of the hardcoded list in the template assets and in other places like the component overview.

See:

* https://github.com/zendframework/zf-mkdoc-theme/blob/master/asset/js/component-list.js
* https://github.com/zendframework/zendframework.github.io/issues/12